### PR TITLE
Added an offset to "b" to find the closing quotes

### DIFF
--- a/src/js/PSVUtils.js
+++ b/src/js/PSVUtils.js
@@ -118,7 +118,7 @@ PSVUtils.getXMPValue = function(data, attr) {
     return data.substring(a, b).replace('<GPano:' + attr + '>', '');
   }
   // XMP data are stored in attributes
-  else if ((a = data.indexOf('GPano:' + attr)) !== -1 && (b = data.indexOf('"', a)) !== -1) {
+  else if ((a = data.indexOf('GPano:' + attr)) !== -1 && (b = data.indexOf('"', a + attr.length + 8)) !== -1) {
     return data.substring(a + attr.length + 8, b);
   }
   else {


### PR DESCRIPTION
"b" needs an offset to find the closing quote for the attribute, otherwise the opening quote will be found and the returned attribute value is null.