### PR TITLE
temp fallback for IE8/9/10/EDGE Windows Phone 8.1

### DIFF
--- a/src/js/PSVUtils.js
+++ b/src/js/PSVUtils.js
@@ -221,10 +221,13 @@ PSVUtils.parsePosition = function(value) {
   var parsed = PSVUtils.getStyle(e, 'background-position').match(/^([0-9.]+)% ([0-9.]+)%$/);
   document.body.removeChild(e);
 
-  return {
-    left: parsed[1] / 100,
-    top: parsed[2] / 100
-  };
+  if(!parsed)
+    return { top: 0.5, left: 0.5 };
+  else
+    return {
+      left: parsed[1] / 100,
+      top: parsed[2] / 100
+    };
 };
 
 /**


### PR DESCRIPTION
IE has a problem with parsing background-position from string 'bottom center' to percentage values '100% 0%'