### PR TITLE
'[\r\n]' regex to [\r\n]{2,}

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
           process: function(src, path) {
             if (path.match(/\.svg$/)) {
               var filename = path.split('/').pop();
-              src = src.replace(/[\r\n]/, '');
+              src = src.replace(/[\r\n]{2,}/, '');
               return 'PhotoSphereViewer.ICONS[\'' + filename + '\'] = \'' + src + '\';';
             }
             else {


### PR DESCRIPTION
{2,} -> match two or more of the token

I get this error in using a Windows environment

![build](https://cloud.githubusercontent.com/assets/1388065/13528562/09b477b2-e217-11e5-997d-7cf874176ca0.PNG)
