### PR TITLE
More robust retrieval of attributes.

### DIFF
--- a/src/js/PSVUtils.js
+++ b/src/js/PSVUtils.js
@@ -204,14 +204,14 @@ PSVUtils.stayBetween = function(x, min, max) {
  * @return (string) The value of the attribute
  */
 PSVUtils.getXMPValue = function(data, attr) {
-  var a, b;
+  var a, b, matchResult;
   // XMP data are stored in children
   if ((a = data.indexOf('<GPano:' + attr + '>')) !== -1 && (b = data.indexOf('</GPano:' + attr + '>')) !== -1) {
     return data.substring(a, b).replace('<GPano:' + attr + '>', '');
   }
   // XMP data are stored in attributes
-  else if ((a = data.indexOf('GPano:' + attr)) !== -1 && (b = data.indexOf('"', a + attr.length + 8)) !== -1) {
-    return data.substring(a + attr.length + 8, b);
+  else if (matchResult = data.match('GPano:'+attr+'=\"(.*?)"')) {
+    return matchResult[1];
   }
   else {
     return null;


### PR DESCRIPTION
This may be a more robust way to retrieve values from the XMP data. regex may allow for more reliable results over using substring.

With my Google Street View Panoramas shot on iPhone I was running into the following console errors:
```
THREE.WebGLRenderer: image is not power of two (0x0). Resized to 0x0 <canvas width=​"0" height=​"0">​
THREE.WebGLRenderer: Texture is not power of two. Texture.minFilter should be set to THREE.NearestFilter or THREE.LinearFilter. T…E.Texture {uuid: "894A673E-E8D7-4EF2-8B25-09154ED4AC33", name: "", sourceFile: "", image: canvas, mipmaps: Array[0]…}
WebGL: INVALID_VALUE: texImage2D: no canvas
```

Digging into the source it had to do with the substring failing to accurately extract the width and height from the XMP data.

My data:

```
<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="XMP Core 5.4.0"> 
<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"> 
<rdf:Description rdf:about="" xmlns:GPano="http://ns.google.com/photos/1.0/panorama/" 
GPano:ProjectionType="equirectangular" 
GPano:CaptureSoftware="Street View - 2.0.4" 
GPano:FullPanoHeightPixels="4352" 
GPano:ExposureLockUsed="False" 
GPano:FirstPhotoDate="2016:02:27 12:44:01-05:00"
GPano:CroppedAreaImageWidthPixels="8704" 
GPano:StitchingSoftware="Street View - 2.0.4" 
GPano:CroppedAreaTopPixels="0" 
GPano:UsePanoramaViewer="True" 
GPano:PoseHeadingDegrees="213" 
GPano:CroppedAreaLeftPixels="0" 
GPano:CroppedAreaImageHeightPixels="4352" 
GPano:LastPhotoDate="2016:02:27 12:48:22-05:00" 
GPano:FullPanoWidthPixels="8704" 
GPano:SourcePhotosCount="46"/>
</rdf:RDF>
```

`PSVUtils.getXMPValue(data, 'FullPanoWidthPixels')` resulted in `"` which is clearly not a number or the value, but rather happens to be the open quotation for the value in the string. This is because the value of b is off. It is set with `b = data.indexOf('"', a)` which starts searching at the beginning of index `a` which is the binging of our attribute name for the first (opening) double quote which will be our opening double quote. b needs to be the index of the second `"`.

Nevertheless doing a regex `data.match('GPano:'+attr+'=\"(.*?)"'))` will eliminate all the off-by-one and miscellaneous substring math and should prove pretty robust for us.

Here is a demo of what it'd look like searching for the width:
![Regular expression visualization](https://www.debuggex.com/i/qWveak9aresoUd7r.png)
[Debuggex Demo](https://www.debuggex.com/r/qWveak9aresoUd7r)

If you like I could fix a regex up for the XMP data are stored in children as well. Though I don't have any samples of it.

Let me know what you think! Love the project, it's slick! 👍 