### PR TITLE
Adding three dependancy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   },
   "scripts": {
     "test": "grunt test"
+  },
+  "dependencies": {
+    "three": "^0.81.2"
   }
 }


### PR DESCRIPTION
**Changes**
When installing Photo-Sphere-Viewer via npm, the package fails to properly install and run since the dependency of three.js is n't in the packages.json. This adds it in to make Photo-Sphere-Viewer happy when installed for a project using npm.

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/Photo-Sphere-Viewer/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] I **didn't** commited files in the `dist` directory
- [x] Unit tests are OK

