### PR TITLE
Improve animate and gotoMarker methods don't always return a promise

### DIFF
--- a/src/js/PhotoSphereViewer.public.js
+++ b/src/js/PhotoSphereViewer.public.js
@@ -397,13 +397,15 @@ PhotoSphereViewer.prototype.rotate = function(position, render) {
  * Rotate the camera with animation
  * @param {object} position - latitude & longitude or x & y
  * @param {string|int} duration - animation speed (per spec) or duration (milliseconds)
+ * @return {Promise} Returns a promise witch will be resolved when the animation finishes
  */
 PhotoSphereViewer.prototype.animate = function(position, duration) {
   this.stopAll();
 
   if (!duration) {
     this.rotate(position);
-    return;
+
+    return D.resolved();
   }
 
   this.cleanPosition(position);

--- a/src/js/components/PSVHUD.js
+++ b/src/js/components/PSVHUD.js
@@ -206,10 +206,11 @@ PSVHUD.prototype.clearMarkers = function(render) {
  * Go to a specific marker
  * @param {*} marker
  * @param {string|int} [duration]
+ * @return {Promise}  A promise that will be resolved When the animation finis
  */
 PSVHUD.prototype.gotoMarker = function(marker, duration) {
   marker = this.getMarker(marker);
-  this.psv.animate(marker, duration);
+  return this.psv.animate(marker, duration);
 };
 
 /**


### PR DESCRIPTION
- Fix animate method won't return a promise for duration 0. (Multiple return paths)
- Fix gotoMarker won't return a promise when the animation to marker finishes

IMO if we return a promise on animate we should always return a promise even if we don't need one because it can cause a fail when multiple promises are chained together. Also `animates` method sometimes return a promise and `gotoMarker` won't. The api should be more consistent. 

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/Photo-Sphere-Viewer/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] Unit tests are OK
