### PR TITLE
Resolve: unable to scroll content panel on mobile device

### DIFF
--- a/src/js/buttons/PSVNavBarZoomButton.js
+++ b/src/js/buttons/PSVNavBarZoomButton.js
@@ -241,7 +241,6 @@ PSVNavBarZoomButton.prototype._changeZoomByTouch = function(evt) {
   if (!this.enabled) {
     return;
   }
-  
   this._changeZoom(evt.changedTouches[0].clientX);
 };
 

--- a/src/js/buttons/PSVNavBarZoomButton.js
+++ b/src/js/buttons/PSVNavBarZoomButton.js
@@ -73,8 +73,8 @@ PSVNavBarZoomButton.prototype.create = function() {
 
   this.zoom_range.addEventListener('mousedown', this);
   this.zoom_range.addEventListener('touchstart', this);
-  this.zoom_range.addEventListener('mousemove', this);
-  this.zoom_range.addEventListener('touchmove', this);
+  this.psv.container.addEventListener('mousemove', this);
+  this.psv.container.addEventListener('touchmove', this);
   this.psv.container.addEventListener('mouseup', this);
   this.psv.container.addEventListener('touchend', this);
   zoom_minus.addEventListener('mousedown', this._zoomOut.bind(this));
@@ -91,6 +91,8 @@ PSVNavBarZoomButton.prototype.create = function() {
  * @override
  */
 PSVNavBarZoomButton.prototype.destroy = function() {
+  this.psv.container.removeEventListener('mousemove', this);
+  this.psv.container.removeEventListener('touchmove', this);
   this.psv.container.removeEventListener('mouseup', this);
   this.psv.container.removeEventListener('touchend', this);
 

--- a/src/js/buttons/PSVNavBarZoomButton.js
+++ b/src/js/buttons/PSVNavBarZoomButton.js
@@ -241,8 +241,7 @@ PSVNavBarZoomButton.prototype._changeZoomByTouch = function(evt) {
   if (!this.enabled) {
     return;
   }
-
-  evt.preventDefault();
+  
   this._changeZoom(evt.changedTouches[0].clientX);
 };
 

--- a/src/js/buttons/PSVNavBarZoomButton.js
+++ b/src/js/buttons/PSVNavBarZoomButton.js
@@ -73,8 +73,8 @@ PSVNavBarZoomButton.prototype.create = function() {
 
   this.zoom_range.addEventListener('mousedown', this);
   this.zoom_range.addEventListener('touchstart', this);
-  this.psv.container.addEventListener('mousemove', this);
-  this.psv.container.addEventListener('touchmove', this);
+  this.zoom_range.addEventListener('mousemove', this);
+  this.zoom_range.addEventListener('touchmove', this);
   this.psv.container.addEventListener('mouseup', this);
   this.psv.container.addEventListener('touchend', this);
   zoom_minus.addEventListener('mousedown', this._zoomOut.bind(this));
@@ -91,8 +91,6 @@ PSVNavBarZoomButton.prototype.create = function() {
  * @override
  */
 PSVNavBarZoomButton.prototype.destroy = function() {
-  this.psv.container.removeEventListener('mousemove', this);
-  this.psv.container.removeEventListener('touchmove', this);
   this.psv.container.removeEventListener('mouseup', this);
   this.psv.container.removeEventListener('touchend', this);
 

--- a/src/js/components/PSVPanel.js
+++ b/src/js/components/PSVPanel.js
@@ -194,7 +194,6 @@ PSVPanel.prototype._onMouseMove = function(evt) {
  */
 PSVPanel.prototype._onTouchMove = function(evt) {
   if (this.prop.mousedown) {
-    evt.stopPropagation();
     this._resize(evt.touches[0]);
   }
 };

--- a/src/js/components/PSVPanel.js
+++ b/src/js/components/PSVPanel.js
@@ -63,18 +63,16 @@ PSVPanel.prototype.create = function() {
   var resizer = this.container.querySelector('.psv-panel-resizer');
   resizer.addEventListener('mousedown', this);
   resizer.addEventListener('touchstart', this);
+  resizer.addEventListener('mousemove', this);
+  resizer.addEventListener('touchmove', this);
   this.psv.container.addEventListener('mouseup', this);
   this.psv.container.addEventListener('touchend', this);
-  this.psv.container.addEventListener('mousemove', this);
-  this.psv.container.addEventListener('touchmove', this);
 };
 
 /**
  * @override
  */
 PSVPanel.prototype.destroy = function() {
-  this.psv.container.removeEventListener('mousemove', this);
-  this.psv.container.removeEventListener('touchmove', this);
   this.psv.container.removeEventListener('mouseup', this);
   this.psv.container.removeEventListener('touchend', this);
 

--- a/src/js/components/PSVPanel.js
+++ b/src/js/components/PSVPanel.js
@@ -63,16 +63,18 @@ PSVPanel.prototype.create = function() {
   var resizer = this.container.querySelector('.psv-panel-resizer');
   resizer.addEventListener('mousedown', this);
   resizer.addEventListener('touchstart', this);
-  resizer.addEventListener('mousemove', this);
-  resizer.addEventListener('touchmove', this);
   this.psv.container.addEventListener('mouseup', this);
   this.psv.container.addEventListener('touchend', this);
+  this.psv.container.addEventListener('mousemove', this);
+  this.psv.container.addEventListener('touchmove', this);
 };
 
 /**
  * @override
  */
 PSVPanel.prototype.destroy = function() {
+  this.psv.container.removeEventListener('mousemove', this);
+  this.psv.container.removeEventListener('touchmove', this);
   this.psv.container.removeEventListener('mouseup', this);
   this.psv.container.removeEventListener('touchend', this);
 


### PR DESCRIPTION
I remove the prevent bubling instructions on touchmove events for resizer and zoom slider because it blocks the scrolling of the lateral panel on mobile devices.

Tha problem can be see here: https://youtu.be/UsuCsb1vBBc
emulated with chrome.

As you can see, if you grab the panel in the gmaps iframe, it scrolls fine, but if you try on regular html you can't scroll.