### PR TITLE
Add main property in package.json for better import/require support

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "threejs"
   ],
   "license": "MIT",
+  "main": "dist/photo-sphere-viewer.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/mistic100/Photo-Sphere-Viewer.git"


### PR DESCRIPTION
In certain circumstances I have to import psv by using `import * as PhotoSphereVIewer from 'photo-sphere-viewer/dist/photo-sphere-viewer'`, because it doesn't understand by default where the entry script is.

By adding a "main" property to the package.json that points to the dist folder, importing/requiring should be more flexible (with full backwards compatibilty). 

**Merge request checklist**

- [✔ ] I read the [guidelines for contributing](https://github.com/mistic100/Photo-Sphere-Viewer/blob/master/.github/CONTRIBUTING.md)
- [✔ ] I created my branch from `dev` and I am issuing the PR to `dev`
- [ ✔] Unit tests are OK
