### PR TITLE
add with_credentials parameter

### DIFF
--- a/src/js/PhotoSphereViewer.core.js
+++ b/src/js/PhotoSphereViewer.core.js
@@ -63,6 +63,9 @@ PhotoSphereViewer.prototype._loadXMP = function(panorama) {
 
   var defer = D();
   var xhr = new XMLHttpRequest();
+  if (this.config.with_credentials) {
+    xhr.withCredentials = true;
+  }
   var progress = 0;
 
   xhr.onreadystatechange = function() {
@@ -216,7 +219,12 @@ PhotoSphereViewer.prototype._loadEquirectangularTexture = function(panorama) {
     var loader = new THREE.ImageLoader();
     var progress = pano_data ? 100 : 0;
 
-    loader.setCrossOrigin('anonymous');
+    if (this.config.with_credentials) {
+      loader.setCrossOrigin('use-credentials');
+    }
+    else {
+      loader.setCrossOrigin('anonymous');
+    }
 
     var onload = function(img) {
       progress = 100;
@@ -336,7 +344,12 @@ PhotoSphereViewer.prototype._loadCubemapTexture = function(panorama) {
   var loaded = [];
   var done = 0;
 
-  loader.setCrossOrigin('anonymous');
+  if (this.config.with_credentials) {
+    loader.setCrossOrigin('use-credentials');
+  }
+  else {
+    loader.setCrossOrigin('anonymous');
+  }
 
   var onend = function() {
     loaded.forEach(function(img) {

--- a/src/js/PhotoSphereViewer.defaults.js
+++ b/src/js/PhotoSphereViewer.defaults.js
@@ -184,7 +184,8 @@ PhotoSphereViewer.DEFAULTS = {
   size: null,
   cache_texture: 0,
   templates: {},
-  markers: []
+  markers: [],
+  with_credentials: false
 };
 
 /**


### PR DESCRIPTION
**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/Photo-Sphere-Viewer/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] Unit tests are OK 

Add 'with_credentials' parameter to PhotoSphereViewer constructor for sending AJAX requests with credentials so as to access secured pictures.
