### PR TITLE
Bugfix: getWebGLCtx was returning false on supported environments

### DIFF
--- a/src/data/system.js
+++ b/src/data/system.js
@@ -67,7 +67,7 @@ function getWebGLCtx() {
   if (names.some((name) => {
     try {
       context = canvas.getContext(name);
-      return true;
+      return context !== null;
     }
     catch (e) {
       return false;


### PR DESCRIPTION
Hi!

I'm updating my code to use the new release of this library and I came across a compatibility problem with IE11 (not that we care a lot, but a lot of people on our website actually use it 😅).

Anyway, the visor was throwing an error indicating that WebGL was not supported, which was weird as we are using another library that uses it without any problem.

After taking a look at the code, it appears that the following fragment inside the `getWebGLCtx` method always returns after the first element inside the `names` array (**some** checks for the first "truthful").

```javascript
const names = ['webgl', 'experimental-webgl', 'moz-webgl', 'webkit-3d'];

[...code...]

names.some((name) => {
  try {
    context = canvas.getContext(name);
    return true;
  }
  catch (e) {
    return false;
  }
});
```

According to the [HTMLCanvasStandard](https://html.spec.whatwg.org/dev/canvas.html#dom-canvas-getcontext), the `getContext` method will just return null if the context is not supported, thus always returning true to the **webgl** context (the first one in the array) even if it's not supported.

This PR changes the returning condition to check if the value is different from null.

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/Photo-Sphere-Viewer/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] Unit tests are OK