### PR TITLE
Feature/two fingers delay

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -32,7 +32,7 @@ export const LONGTOUCH_DELAY = 500;
  * @type {number}
  * @constant
  */
-export const TWOFINGERSOVERLAY_DELAY = 200;
+export const TWOFINGERSOVERLAY_DELAY = 100;
 
 /**
  * @summary Time size of the mouse position history used to compute inertia

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -27,6 +27,14 @@ export const DBLCLICK_DELAY = 300;
 export const LONGTOUCH_DELAY = 500;
 
 /**
+ * @summary Delay in milliseconds to for the two fingers overlay to appear
+ * @memberOf PSV.constants
+ * @type {number}
+ * @constant
+ */
+export const TWOFINGERSOVERLAY_DELAY = 200;
+
+/**
  * @summary Time size of the mouse position history used to compute inertia
  * @memberOf PSV.constants
  * @type {number}

--- a/src/services/EventsHandler.js
+++ b/src/services/EventsHandler.js
@@ -6,6 +6,7 @@ import {
   IDS,
   INERTIA_WINDOW,
   LONGTOUCH_DELAY,
+  TWOFINGERSOVERLAY_DELAY,
   MOVE_THRESHOLD
 } from '../data/constants';
 import { SYSTEM } from '../data/system';
@@ -109,6 +110,7 @@ export class EventsHandler extends AbstractService {
 
     clearTimeout(this.state.dblclickTimeout);
     clearTimeout(this.state.longtouchTimeout);
+    clearTimeout(this.state.twofingersTimeout);
 
     delete this.state;
 
@@ -331,9 +333,7 @@ export class EventsHandler extends AbstractService {
     }
 
     if (this.config.touchmoveTwoFingers) {
-      if (this.twofingersTimeout) {
-        clearTimeout(this.twofingersTimeout);
-      }
+      this.__cancelTwoFingersOverlay();
       this.psv.overlay.hide(IDS.TWO_FINGERS);
     }
   }
@@ -349,14 +349,14 @@ export class EventsHandler extends AbstractService {
     }
 
     if (evt.touches.length === 1) {
-      if (this.config.touchmoveTwoFingers) {
-        this.twofingersTimeout = setTimeout(() => {
+      if (this.config.touchmoveTwoFingers && !this.prop.twofingersTimeout) {
+        this.prop.twofingersTimeout = setTimeout(() => {
           this.psv.overlay.show({
-            id   : IDS.TWO_FINGERS,
+            id: IDS.TWO_FINGERS,
             image: gestureIcon,
-            text : this.config.lang.twoFingers[0],
+            text: this.config.lang.twoFingers[0],
           });
-        }, 200);
+        }, TWOFINGERSOVERLAY_DELAY);
       }
       else {
         evt.preventDefault();
@@ -366,8 +366,8 @@ export class EventsHandler extends AbstractService {
     else if (evt.touches.length === 2) {
       evt.preventDefault();
       this.__moveZoom(evt);
-      if (this.twofingersTimeout) {
-        clearTimeout(this.twofingersTimeout);
+      if (this.config.touchmoveTwoFingers) {
+        this.__cancelTwoFingersOverlay();
       }
     }
   }
@@ -380,6 +380,13 @@ export class EventsHandler extends AbstractService {
     if (this.prop.longtouchTimeout) {
       clearTimeout(this.prop.longtouchTimeout);
       this.prop.longtouchTimeout = null;
+    }
+  }
+
+  __cancelTwoFingersOverlay() {
+    if (this.prop.twofingersTimeout) {
+      clearTimeout(this.prop.twofingersTimeout);
+      this.prop.twofingersTimeout = null;
     }
   }
 

--- a/src/services/EventsHandler.js
+++ b/src/services/EventsHandler.js
@@ -349,14 +349,16 @@ export class EventsHandler extends AbstractService {
     }
 
     if (evt.touches.length === 1) {
-      if (this.config.touchmoveTwoFingers && !this.prop.twofingersTimeout) {
-        this.prop.twofingersTimeout = setTimeout(() => {
-          this.psv.overlay.show({
-            id: IDS.TWO_FINGERS,
-            image: gestureIcon,
-            text: this.config.lang.twoFingers[0],
-          });
-        }, TWOFINGERSOVERLAY_DELAY);
+      if (this.config.touchmoveTwoFingers) {
+        if (!this.prop.twofingersTimeout) {
+          this.prop.twofingersTimeout = setTimeout(() => {
+            this.psv.overlay.show({
+              id: IDS.TWO_FINGERS,
+              image: gestureIcon,
+              text: this.config.lang.twoFingers[0],
+            });
+          }, TWOFINGERSOVERLAY_DELAY);
+        }
       }
       else {
         evt.preventDefault();

--- a/src/services/EventsHandler.js
+++ b/src/services/EventsHandler.js
@@ -54,6 +54,7 @@ export class EventsHandler extends AbstractService {
       dblclickData    : null,
       dblclickTimeout : null,
       longtouchTimeout: null,
+      twofingersTimeout: null,
     };
 
     /**
@@ -330,6 +331,9 @@ export class EventsHandler extends AbstractService {
     }
 
     if (this.config.touchmoveTwoFingers) {
+      if (this.twofingersTimeout) {
+        clearTimeout(this.twofingersTimeout);
+      }
       this.psv.overlay.hide(IDS.TWO_FINGERS);
     }
   }
@@ -346,11 +350,13 @@ export class EventsHandler extends AbstractService {
 
     if (evt.touches.length === 1) {
       if (this.config.touchmoveTwoFingers) {
-        this.psv.overlay.show({
-          id   : IDS.TWO_FINGERS,
-          image: gestureIcon,
-          text : this.config.lang.twoFingers[0],
-        });
+        this.twofingersTimeout = setTimeout(() => {
+          this.psv.overlay.show({
+            id   : IDS.TWO_FINGERS,
+            image: gestureIcon,
+            text : this.config.lang.twoFingers[0],
+          });
+        }, 200);
       }
       else {
         evt.preventDefault();
@@ -360,6 +366,9 @@ export class EventsHandler extends AbstractService {
     else if (evt.touches.length === 2) {
       evt.preventDefault();
       this.__moveZoom(evt);
+      if (this.twofingersTimeout) {
+        clearTimeout(this.twofingersTimeout);
+      }
     }
   }
 

--- a/src/services/EventsHandler.js
+++ b/src/services/EventsHandler.js
@@ -385,6 +385,10 @@ export class EventsHandler extends AbstractService {
     }
   }
 
+  /**
+   * @summary Cancel the two fingers overlay timer if any
+   * @private
+   */
   __cancelTwoFingersOverlay() {
     if (this.prop.twofingersTimeout) {
       clearTimeout(this.prop.twofingersTimeout);


### PR DESCRIPTION
With the two fingers overlay enabled, when dragging with two fingers, the overlay would appear constantly because sometimes, it would register one finger momentously. With this pull request, I added a small delay (100ms) to prevent that. 