### PR TITLE
Fix ZoomRangeButton bug preventing text selection

### DIFF
--- a/src/buttons/ZoomRangeButton.js
+++ b/src/buttons/ZoomRangeButton.js
@@ -199,7 +199,6 @@ export class ZoomRangeButton extends AbstractButton {
       return;
     }
 
-    evt.preventDefault();
     this.__changeZoom(evt.clientX);
   }
 


### PR DESCRIPTION
Hi!

First of all, thanks for your great work on this project!

I came across a weird behavior causing the text inside of the panel component to be not selectable at all.
I am not sure if this behavior is intentional, but after some debugging I found the cause for this problem in the `ZoomRangeButton.__changeZoomWithMouse` function. The call to `evt.preventDefault()` completely blocks all `mousemove` events for the whole viewer without checking if the mouse is inside the bounds of the ZoomRangeButton.
Therefore this bug only occurred if the `zoomRange` button is added to the navbar.

Removing the `evt.preventDefault()` call seems to fix this problem without breaking anything. (As long as I do not miss any disadvantages coming with this solution.)

**Merge request checklist**

- [X] I read the [guidelines for contributing](https://github.com/mistic100/Photo-Sphere-Viewer/blob/master/.github/CONTRIBUTING.md)
- [X] I created my branch from `dev` and I am issuing the PR to `dev`
- [X] Unit tests are OK
