### PR TITLE
Make it possible to use panoData in VisibleRanges plugin (attempt 2)

### DIFF
--- a/docs/plugins/plugin-visible-range.md
+++ b/docs/plugins/plugin-visible-range.md
@@ -64,7 +64,3 @@ Use cropped panorama data as visible range.
 #### `setLatitudeRange(range)` | `setLongitudeRange(range)`
 
 Change or remove the ranges.
-
-#### `getPanoLatitudeRange()` | `getPanoLongitudeRange()`
-
-Get the viewer's panorama data as latitude and longitude ranges.

--- a/docs/plugins/plugin-visible-range.md
+++ b/docs/plugins/plugin-visible-range.md
@@ -29,6 +29,7 @@ visibleRangePlugin.setLongitudeRange(['0deg', '180deg']);
 visibleRangePlugin.setLatitudeRange(null);
 ```
 
+Alternatively, if `usePanoData` is set to `true`, the visible range is limited to the [cropped panorama data](../guide/cropped-panorama.md#provide-cropping-data) provided to the viewer.
 
 ## Example
 
@@ -51,9 +52,19 @@ Visible longitude as two angles.
 
 Visible latitude as two angles.
 
+#### `usePanoData`
+- type: `boolean`
+- default: `false`
+
+Use cropped panorama data as visible range.
+
 
 ## Methods
 
 #### `setLatitudeRange(range)` | `setLongitudeRange(range)`
 
 Change or remove the ranges.
+
+#### `getPanoLatitudeRange()` | `getPanoLongitudeRange()`
+
+Get the viewer's panorama data as latitude and longitude ranges.

--- a/src/plugins/visible-range/index.js
+++ b/src/plugins/visible-range/index.js
@@ -136,12 +136,11 @@ export default class VisibleRangePlugin extends AbstractPlugin {
    */
   getPanoLatitudeRange() {
     const p = this.psv.prop.panoData;
-    if (p.croppedHeight == p.fullHeight && p.croppedY == 0) {
+    if (p.croppedHeight === p.fullHeight && p.croppedY === 0) {
       return null;
-    } else {
-      function latitude(y) {
-        return Math.PI * (y / p.fullHeight) - (Math.PI / 2);
-      }
+    }
+    else {
+      const latitude = (y) => Math.PI * (y / p.fullHeight) - (Math.PI / 2);
       return [latitude(p.croppedY), latitude(p.croppedY + p.croppedHeight)];
     }
   }
@@ -151,12 +150,11 @@ export default class VisibleRangePlugin extends AbstractPlugin {
    */
   getPanoLongitudeRange() {
     const p = this.psv.prop.panoData;
-    if (p.croppedWidth == p.fullWidth && p.croppedX == 0) {
+    if (p.croppedWidth === p.fullWidth && p.croppedX === 0) {
       return null;
-    } else {
-      function longitude(x) {
-        return 2 * Math.PI * (x / p.fullWidth);
-      }
+    }
+    else {
+      const longitude = (x) => 2 * Math.PI * (x / p.fullWidth);
       return [longitude(p.croppedX), longitude(p.croppedX + p.croppedWidth)];
     }
   }

--- a/src/plugins/visible-range/index.js
+++ b/src/plugins/visible-range/index.js
@@ -5,6 +5,7 @@ import * as THREE from 'three';
  * @typedef {Object} PSV.plugins.VisibleRangePlugin.Options
  * @property {double[]|string[]} [latitudeRange] - latitude range as two angles
  * @property {double[]|string[]} [longitudeRange] - longitude range as two angles
+ * @property {boolean} [usePanoData] - if true use panoData as visible range
  */
 
 /**
@@ -33,6 +34,10 @@ export default class VisibleRangePlugin extends AbstractPlugin {
     };
 
     if (options) {
+      if (options.usePanoData) {
+        options.latitudeRange = this.getPanoLatitudeRange();
+        options.longitudeRange = this.getPanoLongitudeRange();
+      }
       this.setLatitudeRange(options.latitudeRange);
       this.setLongitudeRange(options.longitudeRange);
     }
@@ -123,6 +128,36 @@ export default class VisibleRangePlugin extends AbstractPlugin {
 
     if (this.psv.prop.ready) {
       this.psv.rotate(this.psv.getPosition());
+    }
+  }
+
+  /**
+   * @summary Gets the latitude range defined by the viewer's panoData
+   */
+  getPanoLatitudeRange() {
+    const p = this.psv.prop.panoData;
+    if (p.croppedHeight == p.fullHeight && p.croppedY == 0) {
+      return null;
+    } else {
+      function latitude(y) {
+        return Math.PI * (y / p.fullHeight) - (Math.PI / 2);
+      }
+      return [latitude(p.croppedY), latitude(p.croppedY + p.croppedHeight)];
+    }
+  }
+
+  /**
+   * @summary Gets the longitude range defined by the viewer's panoData
+   */
+  getPanoLongitudeRange() {
+    const p = this.psv.prop.panoData;
+    if (p.croppedWidth == p.fullWidth && p.croppedX == 0) {
+      return null;
+    } else {
+      function longitude(x) {
+        return 2 * Math.PI * (x / p.fullWidth);
+      }
+      return [longitude(p.croppedX), longitude(p.croppedX + p.croppedWidth)];
     }
   }
 

--- a/src/plugins/visible-range/index.js
+++ b/src/plugins/visible-range/index.js
@@ -133,6 +133,8 @@ export default class VisibleRangePlugin extends AbstractPlugin {
 
   /**
    * @summary Gets the latitude range defined by the viewer's panoData
+   * @returns {double[]|null}
+   * @private
    */
   getPanoLatitudeRange() {
     const p = this.psv.prop.panoData;
@@ -147,6 +149,8 @@ export default class VisibleRangePlugin extends AbstractPlugin {
 
   /**
    * @summary Gets the longitude range defined by the viewer's panoData
+   * @returns {double[]|null}
+   * @private
    */
   getPanoLongitudeRange() {
     const p = this.psv.prop.panoData;

--- a/src/plugins/visible-range/index.js
+++ b/src/plugins/visible-range/index.js
@@ -140,7 +140,7 @@ export default class VisibleRangePlugin extends AbstractPlugin {
       return null;
     }
     else {
-      const latitude = (y) => Math.PI * (y / p.fullHeight) - (Math.PI / 2);
+      const latitude = y => Math.PI * (y / p.fullHeight) - (Math.PI / 2);
       return [latitude(p.croppedY), latitude(p.croppedY + p.croppedHeight)];
     }
   }
@@ -154,7 +154,7 @@ export default class VisibleRangePlugin extends AbstractPlugin {
       return null;
     }
     else {
-      const longitude = (x) => 2 * Math.PI * (x / p.fullWidth);
+      const longitude = x => 2 * Math.PI * (x / p.fullWidth);
       return [longitude(p.croppedX), longitude(p.croppedX + p.croppedWidth)];
     }
   }


### PR DESCRIPTION
Make it easy to limit the visible range to the cropped panorama
data already set on the viewer with XMP or through panoData.

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/Photo-Sphere-Viewer/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [ ] Unit tests are OK

Another attempt at a fix for #476, without the messed up branch.

I have the getPanoLatitudeRange and getPanoLongitudeRange in my own code outside of the photo viewer so I know that it works in theory at least, but I have not tested this code in this repo. :grimacing: My JavaScript knowledge is a little, um, old-school, so I'm not sure how to actually build, run and test this here.

I have also only tested this code with images with XMP data (and images with no XMP data at all), I have not tested it with manually set panoData (using values or a callback).
