### PR TITLE
Correct VisibleRange longitudeRange for panoData

### DIFF
--- a/src/plugins/visible-range/index.js
+++ b/src/plugins/visible-range/index.js
@@ -118,7 +118,7 @@ export default class VisibleRangePlugin extends AbstractPlugin {
       // eslint-disable-next-line no-param-reassign
       range = null;
     }
-    // longitude range is between 0 (center of panorama) and 2*PI
+    // longitude range is between 0 and 2*PI
     if (range) {
       this.config.longitudeRange = range.map(angle => utils.parseAngle(angle));
     }

--- a/src/plugins/visible-range/index.js
+++ b/src/plugins/visible-range/index.js
@@ -118,7 +118,7 @@ export default class VisibleRangePlugin extends AbstractPlugin {
       // eslint-disable-next-line no-param-reassign
       range = null;
     }
-    // longitude range is between 0 and 2*PI
+    // longitude range is between 0 (center of panorama) and 2*PI
     if (range) {
       this.config.longitudeRange = range.map(angle => utils.parseAngle(angle));
     }
@@ -158,7 +158,7 @@ export default class VisibleRangePlugin extends AbstractPlugin {
       return null;
     }
     else {
-      const longitude = x => 2 * Math.PI * (x / p.fullWidth);
+      const longitude = x => 2 * Math.PI * (x / p.fullWidth) - Math.PI;
       return [longitude(p.croppedX), longitude(p.croppedX + p.croppedWidth)];
     }
   }


### PR DESCRIPTION
The longitude range is 0 to 2*PI, but zero does not correspond
to the left edge of the full panorama, it corresponds to the
panorama's center.

Correct getPanoLongitudeRange() to return a range between
-PI (left edge) and +PI (right edge). setLongitudeRange()
converts this to values in the 0 to 2*PI range.

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/Photo-Sphere-Viewer/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] Unit tests are OK

Fix for the bug I noticed after #478 got merged.