### PR TITLE
Increase MOVE_THRESHOLD

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -8,7 +8,7 @@
  * @type {number}
  * @constant
  */
-export const MOVE_THRESHOLD = 50;
+export const MOVE_THRESHOLD = window.innerWidth <= 1366 && (window.navigator.maxTouchPoints > 0 || window.navigator.msMaxTouchPoints > 0) ? 20 : 4;
 
 /**
  * @summary Delay in milliseconds between two clicks to consider a double click

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -8,7 +8,7 @@
  * @type {number}
  * @constant
  */
-export const MOVE_THRESHOLD = 4;
+export const MOVE_THRESHOLD = 50;
 
 /**
  * @summary Delay in milliseconds between two clicks to consider a double click


### PR DESCRIPTION
Ipad's running cordova ios apps cant trigger double click by using touch events. The reason for this i found was the lower threshold. With touch it takes incredible precision to trigger double click it however is still possible with 4 just very hard. With stylus/pencil triggering double click was easier but still not consistent. With threshold 50 pixels it was consistently possible to trigger double click with touch while maintaining proper gyroscope control.

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/Photo-Sphere-Viewer/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] Unit tests are OK
