### PR TITLE
Smoother panning to remove jerk when releasing the mouse

### DIFF
--- a/src/services/EventsHandler.js
+++ b/src/services/EventsHandler.js
@@ -648,8 +648,8 @@ export class EventsHandler extends AbstractService {
         clientX: { start: evt.clientX, end: evt.clientX + direction.x },
         clientY: { start: evt.clientY, end: evt.clientY + direction.y },
       },
-      duration  : norm * INERTIA_WINDOW / 100,
-      easing    : 'outCirc',
+      duration  : norm + INERTIA_WINDOW,
+      easing    : 'outQuad',
       onTick    : (properties) => {
         this.__move(properties, false);
       },


### PR DESCRIPTION
#723 fixed the issue where panning inertia was occurring when it shouldn't and causing a visual "jerk" of the panorama. After that fix, the transition from release of the mouse to inertia still had some extra acceleration that was particularly evident for small mouse moves. This PR builds on the last one and switches to `outQuad` easing for a smoother visual start of inertia when releasing the mouse (see https://easings.net/). The animation duration calculation has been adapted to better suit the `outQuad` easing.

Before this PR:
https://user-images.githubusercontent.com/47948499/185695563-dfdfa58e-648c-4468-8f78-033e58fa5253.mp4


After this PR:
https://user-images.githubusercontent.com/47948499/185695571-dee6b80d-3342-440c-b649-56bf9d7b5208.mp4



**Merge request checklist**

- [x] I created my branch from `dev` and I am issuing the PR to `dev`.
- [x] All tests pass. If needed, new unit tests were added (only for utils).
- [ ] If needed, the [types](https://github.com/mistic100/Photo-Sphere-Viewer/tree/dev/types) have been updated.
- [ ] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/dev/docs) has been updated.
