### PR TITLE
fix(iOS-video): display video adaptater on iOS

### DIFF
--- a/src/adapters/shared/AbstractVideoAdapter.js
+++ b/src/adapters/shared/AbstractVideoAdapter.js
@@ -158,7 +158,7 @@ export class AbstractVideoAdapter extends AbstractAdapter {
     const video = document.createElement('video');
     video.crossOrigin = this.psv.config.withCredentials ? 'use-credentials' : 'anonymous';
     video.loop = true;
-    video.playsinline = true;
+    video.playsInline = true;
     video.style.display = 'none';
     video.muted = this.config.muted;
     video.src = src;


### PR DESCRIPTION
## Changes

* Update `playinline` to `playInline` to be able to read the **video** panorama on iOS without using the native iOS viewer.

## Description

There is a bug for iOS devices using the video plugin due to the missing attribute `playinline` during the html5 video tag creation [#L161](https://github.com/mistic100/Photo-Sphere-Viewer/blob/01d98377abd86b9c1183e2d9edbd97c6fd718918/src/adapters/shared/AbstractVideoAdapter.js#L161).

Tests examples of the issue from the [documentation](https://photo-sphere-viewer.js.org/guide/adapters/equirectangular-video.html#example) using an iPhone on Chrome app:
![IMG_1370](https://user-images.githubusercontent.com/50140834/202734402-77a4f74b-827a-49e6-946d-d9ddd1f783ec.png)

## Fix

I don't find good resources covering the issue. But it look like the attribute `playinline` should be in camelCase [#L161](https://github.com/mistic100/Photo-Sphere-Viewer/blob/01d98377abd86b9c1183e2d9edbd97c6fd718918/src/adapters/shared/AbstractVideoAdapter.js#L161)..

This changes fix the issue as i was able to run video on iOS as on Android.

> Will take time to upload a video demo..

**Merge request checklist**

- [x] I created my branch from `dev` and I am issuing the PR to `dev`.
- [x] All tests pass. If needed, new unit tests were added (only for utils).
- [ ] If needed, the [types](https://github.com/mistic100/Photo-Sphere-Viewer/tree/dev/types) have been updated.
- [ ] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/dev/docs) has been updated.
