### PR TITLE
Fix typo in Marker.ts

### DIFF
--- a/packages/markers-plugin/src/Marker.ts
+++ b/packages/markers-plugin/src/Marker.ts
@@ -344,7 +344,7 @@ export class Marker {
                 element.classList.add('psv-marker--has-tooltip');
             }
             if (this.config.content) {
-                element.classList.add('psv-marler--has-content');
+                element.classList.add('psv-marker--has-content');
             }
 
             // apply style


### PR DESCRIPTION
Fixed a typo in `Marker.ts`.
It prevented markers having content but no tooltip to have the `cursor: pointer` attribute.

**Merge request checklist**

-   [x] All lints and tests pass.