### PR TITLE
Virtual-Tour: Rotate before and after a new node, chain nodes

### DIFF
--- a/packages/virtual-tour-plugin/src/VirtualTourPlugin.ts
+++ b/packages/virtual-tour-plugin/src/VirtualTourPlugin.ts
@@ -342,7 +342,7 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
 
         const fromNode = this.state.currentNode;
         const fromLinkPosition = fromNode && fromLink ? this.__getLinkPosition(fromNode, fromLink) : null;
-        const rotateBeforeLoad = fromNode && fromLink ? fromLink.rotateBeforeLoad ?? fromLinkPosition : null;
+        const rotateBeforeLoad = fromNode && fromLink && fromLink.rotateBeforeLoad ? fromLink.rotateBeforeLoad : fromLinkPosition;
 
         return Promise.all([
             // if this node is already preloading, wait for it
@@ -356,7 +356,7 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
             Promise.resolve(rotateBeforeLoad ? this.config.rotateSpeed : false)
                 .then((speed) => {
                     if (speed) {
-                        return this.viewer.animate({ ...fromLinkPosition, speed });
+                        return this.viewer.animate({ ...rotateBeforeLoad, speed });
                     }
                 })
                 .then(() => {

--- a/packages/virtual-tour-plugin/src/VirtualTourPlugin.ts
+++ b/packages/virtual-tour-plugin/src/VirtualTourPlugin.ts
@@ -444,7 +444,7 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
                         }
                     })
                     .then(() => {
-                        const nextNodeId = fromNode && fromLink && currentNode.nextNodeAfterLoad ? currentNode.nextNodeAfterLoad[fromNode.id] : null;
+                        const nextNodeId = fromNode && fromLink ? fromLink.nextNodeId : null;
                         if (nextNodeId) {
                             this.setCurrentNode(nextNodeId, currentNode.links.find(link => link.nodeId === nextNodeId));
                         }

--- a/packages/virtual-tour-plugin/src/VirtualTourPlugin.ts
+++ b/packages/virtual-tour-plugin/src/VirtualTourPlugin.ts
@@ -342,7 +342,7 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
 
         const fromNode = this.state.currentNode;
         const fromLinkPosition = fromNode && fromLink ? this.__getLinkPosition(fromNode, fromLink) : null;
-        const rotateToPosition = fromNode && fromLink ? fromLink.rotateToPosition ?? fromLinkPosition : null;
+        const rotateToPositionBeforeLoad = fromNode && fromLink ? fromLink.rotateToPosition ?? fromLinkPosition : null;
 
         return Promise.all([
             // if this node is already preloading, wait for it
@@ -353,7 +353,7 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
 
                 return this.datasource.loadNode(nodeId);
             }),
-            Promise.resolve(rotateToPosition ? this.config.rotateSpeed : false)
+            Promise.resolve(rotateToPositionBeforeLoad ? this.config.rotateSpeed : false)
                 .then((speed) => {
                     if (speed) {
                         return this.viewer.animate({ ...fromLinkPosition, speed });
@@ -435,12 +435,12 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
             })
             .then(() => {
                 const currentNode = this.state.currentNode;
-                const rotateToPosition = currentNode.rotateToPosition ? utils.isExtendedPosition(currentNode.rotateToPosition) ? currentNode.rotateToPosition : currentNode.rotateToPosition[fromNode?.id] : null;
+                const rotateToPositionAfterLoad = currentNode.rotateToPosition ? utils.isExtendedPosition(currentNode.rotateToPosition) ? currentNode.rotateToPosition : currentNode.rotateToPosition[fromNode?.id] : null;
 
-                Promise.resolve(rotateToPosition ? this.config.rotateSpeed : false)
+                Promise.resolve(rotateToPositionAfterLoad ? this.config.rotateSpeed : false)
                     .then((speed) => {
                         if (speed) {
-                            return this.viewer.animate({ ...rotateToPosition, speed });
+                            return this.viewer.animate({ ...rotateToPositionAfterLoad, speed });
                         }
                     })
                     .then(() => {

--- a/packages/virtual-tour-plugin/src/VirtualTourPlugin.ts
+++ b/packages/virtual-tour-plugin/src/VirtualTourPlugin.ts
@@ -342,7 +342,7 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
 
         const fromNode = this.state.currentNode;
         const fromLinkPosition = fromNode && fromLink ? this.__getLinkPosition(fromNode, fromLink) : null;
-        const rotateToPositionBeforeLoad = fromNode && fromLink ? fromLink.rotateToPosition ?? fromLinkPosition : null;
+        const rotateBeforeLoad = fromNode && fromLink ? fromLink.rotateBeforeLoad ?? fromLinkPosition : null;
 
         return Promise.all([
             // if this node is already preloading, wait for it
@@ -353,7 +353,7 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
 
                 return this.datasource.loadNode(nodeId);
             }),
-            Promise.resolve(rotateToPositionBeforeLoad ? this.config.rotateSpeed : false)
+            Promise.resolve(rotateBeforeLoad ? this.config.rotateSpeed : false)
                 .then((speed) => {
                     if (speed) {
                         return this.viewer.animate({ ...fromLinkPosition, speed });
@@ -435,12 +435,12 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
             })
             .then(() => {
                 const currentNode = this.state.currentNode;
-                const rotateToPositionAfterLoad = currentNode.rotateToPosition ? utils.isExtendedPosition(currentNode.rotateToPosition) ? currentNode.rotateToPosition : currentNode.rotateToPosition[fromNode?.id] : null;
-
-                Promise.resolve(rotateToPositionAfterLoad ? this.config.rotateSpeed : false)
+                const rotateAfterLoad = fromNode && fromLink && fromLink.rotateAfterLoad ? fromLink.rotateAfterLoad : null;
+                
+                Promise.resolve(rotateAfterLoad ? this.config.rotateSpeed : false)
                     .then((speed) => {
                         if (speed) {
-                            return this.viewer.animate({ ...rotateToPositionAfterLoad, speed });
+                            return this.viewer.animate({ ...rotateAfterLoad, speed });
                         }
                     })
                     .then(() => {

--- a/packages/virtual-tour-plugin/src/model.ts
+++ b/packages/virtual-tour-plugin/src/model.ts
@@ -72,13 +72,10 @@ export type VirtualTourLink = Partial<ExtendedPosition> & {
      */
     position?: ExtendedPosition;
     /**
-     * override the position the camera rotates to when the link is clicked
+     * value to be added to the link-yaw in order to move the
+     * marker/arrow without affecting where the viewer is rotated before going to the next node
      */
-    rotateBeforeLoad?: ExtendedPosition;
-    /**
-     * set a position the camera rotates after the new node is loaded
-     */
-    rotateAfterLoad?: ExtendedPosition;
+    linkOffset?: number;
     /**
      * override the GPS position of the node (GPS mode)
      */
@@ -91,10 +88,6 @@ export type VirtualTourLink = Partial<ExtendedPosition> & {
      * override global arrow style
      */
     arrowStyle?: VirtualTourArrowStyle;
-     /**
-     * automatically go to an other node after loading (and optionally rotating) the viewer
-     */
-     nextNodeId?: string;
 };
 
 /**

--- a/packages/virtual-tour-plugin/src/model.ts
+++ b/packages/virtual-tour-plugin/src/model.ts
@@ -87,6 +87,10 @@ export type VirtualTourLink = Partial<ExtendedPosition> & {
      * override global arrow style
      */
     arrowStyle?: VirtualTourArrowStyle;
+     /**
+     * automatically go to an other node after loading (and optionally rotating) the viewer
+     */
+     nextNodeId?: string;
 };
 
 /**
@@ -125,13 +129,9 @@ export type VirtualTourNode = {
     gps?: GpsPosition;
     /**
      * override the position the camera rotates to after the node is loaded 
+     * either a single position or an object: {fromNodeId1: Position, fromNodeId2: Position}
      */
     rotateToPosition?: ExtendedPosition | Record<string, ExtendedPosition>;
-    /**
-     * automatically go to an other node after loading (and optionally rotating) the node
-     * object schema: {fromNode1: toNode3, fromNode3: toNode1}
-     */
-    nextNodeAfterLoad?: Record<string, string>;
     /**
      * thumbnail for the gallery
      */

--- a/packages/virtual-tour-plugin/src/model.ts
+++ b/packages/virtual-tour-plugin/src/model.ts
@@ -74,7 +74,11 @@ export type VirtualTourLink = Partial<ExtendedPosition> & {
     /**
      * override the position the camera rotates to when the link is clicked
      */
-    rotateToPosition?: ExtendedPosition;
+    rotateBeforeLoad?: ExtendedPosition;
+    /**
+     * set a position the camera rotates after the new node is loaded
+     */
+    rotateAfterLoad?: ExtendedPosition;
     /**
      * override the GPS position of the node (GPS mode)
      */
@@ -127,11 +131,6 @@ export type VirtualTourNode = {
      * GPS position
      */
     gps?: GpsPosition;
-    /**
-     * override the position the camera rotates to after the node is loaded 
-     * either a single position or an object: {fromNodeId1: Position, fromNodeId2: Position}
-     */
-    rotateToPosition?: ExtendedPosition | Record<string, ExtendedPosition>;
     /**
      * thumbnail for the gallery
      */

--- a/packages/virtual-tour-plugin/src/model.ts
+++ b/packages/virtual-tour-plugin/src/model.ts
@@ -72,6 +72,10 @@ export type VirtualTourLink = Partial<ExtendedPosition> & {
      */
     position?: ExtendedPosition;
     /**
+     * override the position the camera rotates to when the link is clicked
+     */
+    rotateToPosition?: ExtendedPosition;
+    /**
      * override the GPS position of the node (GPS mode)
      */
     gps?: [number, number, number?];
@@ -119,6 +123,15 @@ export type VirtualTourNode = {
      * GPS position
      */
     gps?: GpsPosition;
+    /**
+     * override the position the camera rotates to after the node is loaded 
+     */
+    rotateToPosition?: ExtendedPosition | Record<string, ExtendedPosition>;
+    /**
+     * automatically go to an other node after loading (and optionally rotating) the node
+     * object schema: {fromNode1: toNode3, fromNode3: toNode1}
+     */
+    nextNodeAfterLoad?: Record<string, string>;
     /**
      * thumbnail for the gallery
      */


### PR DESCRIPTION
For my usecase I added the following features to the Virtual-Tour-Plugin:

- it is possible to overwrite the position to which the camera rotates to, when a link is clicked. This is useful when two links are too close to each other and thus the distance between them (to prevent them from overlapping) needs to be increased. To further ensure that the camera still animates to the right place, this option has been added.
- it is possible to specify a position to which the viewer rotates to, after the new node has been loaded. This is useful when you want to highlight specific things at a node in the tour.
- it is possible to automatically jump to another node after the first one has loaded. With this option it is possible to create "chains" of nodes, which is especially useful when a place is not of great importance in the tour, but it is helpful for orientation to include it as an intermediate step (e.g. on a stair landing, or in an anteroom).

I'd be very happy, if these would make it upstream. Please tell me, what you think about the implementation.

**Merge request checklist**

-   [x] All lints and tests pass.
-   [ ] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated. (Not yet)