### PR TITLE
Download button opens in new tab

### DIFF
--- a/packages/core/src/buttons/DownloadButton.ts
+++ b/packages/core/src/buttons/DownloadButton.ts
@@ -9,7 +9,7 @@ export class DownloadButton extends AbstractButton {
 
     constructor(navbar: Navbar) {
         super(navbar, {
-            className: 'psv-download-butto',
+            className: 'psv-download-button',
             hoverScale: true,
             collapsable: true,
             tabbable: true,
@@ -39,6 +39,7 @@ export class DownloadButton extends AbstractButton {
         } else {
             link.download = this.viewer.config.downloadName || link.href.split('/').pop();
         }
+        link.target = '_blank';
         this.viewer.container.appendChild(link);
         link.click();
 


### PR DESCRIPTION
This PR intends to change the current download button in navbar behaviour, to open offered image download in a new tab instead of redirecting current tab to image. Also fixes a typo in button classname.

**Merge request checklist**

-   [x] All lints and tests pass. If needed, new unit tests were added.
-   [x] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.
