### PR TITLE
Add crossOrigin use-credentials for ThreeJS loaders

### DIFF
--- a/packages/core/src/services/TextureLoader.ts
+++ b/packages/core/src/services/TextureLoader.ts
@@ -19,6 +19,7 @@ export class TextureLoader extends AbstractService {
         this.loader.setResponseType('blob');
         if (this.config.withCredentials) {
             this.loader.setWithCredentials(true);
+            this.loader.setCrossOrigin('use-credentials');
         }
     }
 

--- a/packages/cubemap-tiles-adapter/src/CubemapTilesAdapter.ts
+++ b/packages/cubemap-tiles-adapter/src/CubemapTilesAdapter.ts
@@ -100,6 +100,7 @@ export class CubemapTilesAdapter extends AbstractAdapter<CubemapTilesPanorama | 
             this.loader = new ImageLoader();
             if (this.viewer.config.withCredentials) {
                 this.loader.setWithCredentials(true);
+                this.loader.setCrossOrigin('use-credentials');
             }
         }
 

--- a/packages/equirectangular-tiles-adapter/src/EquirectangularTilesAdapter.ts
+++ b/packages/equirectangular-tiles-adapter/src/EquirectangularTilesAdapter.ts
@@ -154,6 +154,7 @@ export class EquirectangularTilesAdapter extends AbstractAdapter<
             this.loader = new ImageLoader();
             if (this.viewer.config.withCredentials) {
                 this.loader.setWithCredentials(true);
+                this.loader.setCrossOrigin('use-credentials');
             }
         }
 
@@ -355,7 +356,7 @@ export class EquirectangularTilesAdapter extends AbstractAdapter<
                     segmentIndex = Math.floor((i / 3 - this.SPHERE_SEGMENTS) / 2) + this.SPHERE_SEGMENTS;
                 } else {
                     // last row
-                    segmentIndex = Math.floor((i - this.NB_VERTICES - this.SPHERE_SEGMENTS * NB_VERTICES_BY_SMALL_FACE) / 3) 
+                    segmentIndex = Math.floor((i - this.NB_VERTICES - this.SPHERE_SEGMENTS * NB_VERTICES_BY_SMALL_FACE) / 3)
                         + this.SPHERE_HORIZONTAL_SEGMENTS * (this.SPHERE_SEGMENTS - 1);
                 }
                 const segmentRow = Math.floor(segmentIndex / this.SPHERE_SEGMENTS);

--- a/packages/markers-plugin/src/Marker.ts
+++ b/packages/markers-plugin/src/Marker.ts
@@ -67,7 +67,7 @@ export class Marker {
 
     constructor(
         private readonly viewer: Viewer,
-        private readonly plugin: MarkersPlugin, 
+        private readonly plugin: MarkersPlugin,
         config: MarkerConfig
     ) {
         if (!config.id) {
@@ -93,6 +93,7 @@ export class Marker {
             this.loader = new TextureLoader();
             if (this.viewer.config.withCredentials) {
                 this.loader.setWithCredentials(true);
+                this.loader.setCrossOrigin('use-credentials');
             }
         }
 


### PR DESCRIPTION
**Merge request checklist**

-   [x] All lints and tests pass. If needed, new unit tests were added.
-   [x] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.

This PR offers a fix for authentication issue:
- When `Viewer` has parameter `withCredentials: true`
- And an adapter (like EquirectangularTilesAdapter) calls an image protected by credentials authentication (like cookies-based authentication)
- Happens on PSV 5.1.6, on at least Chromium 114 and Firefox 114 under Linux

Currently, adapters delegates loading to ThreeJS `Loader` using the `setWithCredentials` function. This is good, but apparently not enough for browsers: cookies containing authentication information are not sent for tiles. They happen to be sent for base panorama though, so base image appear but not tiles (they end up with HTTP status 403, as no authentication is sent).

_Classic image is called with session cookies :cookie:_ 
![image](https://github.com/mistic100/Photo-Sphere-Viewer/assets/1349014/4d67c3cd-50b9-4ada-9252-e187dd185a1d)

_No cookies for tiles :no_entry_sign: :cookie:_ 
![image](https://github.com/mistic100/Photo-Sphere-Viewer/assets/1349014/079a5ca8-416f-48fd-b909-8e16517f8a9f)


So this PR also adds a ThreeJS Loader call to `setCrossOrigin('use-credentials')` to make sure credentials are sent, solving the issue of tiles not loading.

_Cookies for tiles :cookie: :black_square_button:_
![image](https://github.com/mistic100/Photo-Sphere-Viewer/assets/1349014/84ade8d3-d478-4d03-9410-5c66cb4fdaf4)


This is complex to provide a sandbox demo for this bug, as this happens with an API requiring authentication through same domain name as the one hosting the viewer... Can manage to provide a hosted environment to reproduce this if that's absolute necessity :sweat_smile: 