### PR TITLE
fix: virtual-tour-plugin dont show gallery after node change

### DIFF
--- a/packages/virtual-tour-plugin/src/VirtualTourPlugin.ts
+++ b/packages/virtual-tour-plugin/src/VirtualTourPlugin.ts
@@ -467,6 +467,8 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
                     this.__addNodeMarkers(node);
                 }
 
+                this.gallery?.show();
+                
                 this.__renderLinks(node);
                 this.__preload(node);
 


### PR DESCRIPTION
When node change, virtual tour plugin called this.gallery.hide(), but dont show it again.

May better detect gallery plugin state.visible or something, but I dont get further infomation.

**Merge request checklist**

-   [ ] All lints and tests pass. If needed, new unit tests were added.
-   [ ] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.
