### PR TITLE
fix: when different node with same panorama, may check id also

### DIFF
--- a/packages/gallery-plugin/src/GalleryPlugin.ts
+++ b/packages/gallery-plugin/src/GalleryPlugin.ts
@@ -89,7 +89,7 @@ export class GalleryPlugin extends AbstractConfigurablePlugin<
      */
     handleEvent(e: Event) {
         if (e instanceof events.PanoramaLoadedEvent) {
-            const item = this.items.find((i) => utils.deepEqual(i.panorama, e.data.panorama));
+            const item = this.items.find((i) => utils.deepEqual(i.panorama, e.data.panorama) && i.id === e.data.id);
             this.currentId = item?.id;
             this.gallery.setActive(item?.id);
         } else if (e instanceof events.ShowPanelEvent) {


### PR DESCRIPTION
when different node with same panorama, maybe better check id also?

**Merge request checklist**

-   [ ] All lints and tests pass. If needed, new unit tests were added.
-   [ ] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.
