### PR TITLE
[Config Option] Added showLoader to VirtualTourPlugin

### DIFF
--- a/packages/virtual-tour-plugin/src/VirtualTourPlugin.ts
+++ b/packages/virtual-tour-plugin/src/VirtualTourPlugin.ts
@@ -32,6 +32,7 @@ const getConfig = utils.getConfigParser<VirtualTourPluginConfig>(
         preload: false,
         transitionOptions: {
             speed: '20rpm',
+            showLoader: true,
             fadeIn: true,
             rotation: true,
         },
@@ -394,6 +395,7 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
 
                 const transitionOptions: VirtualTourTransitionOptions = {
                     speed: (getConfig.defaults.transitionOptions as any).speed,
+                    showLoader: (getConfig.defaults.transitionOptions as any).showLoader,
                     fadeIn: (getConfig.defaults.transitionOptions as any).fadeIn,
                     rotation: (getConfig.defaults.transitionOptions as any).rotation,
                     rotateTo: fromLinkPosition,
@@ -419,7 +421,10 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
                     throw utils.getAbortError();
                 }
 
-                this.viewer.loader.show();
+                if(transitionOptions.showLoader)
+                {
+                    this.viewer.loader.show();
+                }
 
                 this.state.currentNode = node;
 
@@ -444,6 +449,7 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
                         sphereCorrection: node.sphereCorrection,
                         transition: !transitionOptions.fadeIn ? false : transitionOptions.rotation ? true : 'fade-only',
                         speed: transitionOptions.speed,
+                        showLoader: transitionOptions.showLoader,
                         position: transitionOptions.rotateTo,
                         zoom: transitionOptions.zoomTo,
                     })
@@ -612,7 +618,7 @@ export class VirtualTourPlugin extends AbstractConfigurablePlugin<
                         id: marker.id,
                         tooltip: {
                             className: 'psv-virtual-tour-tooltip',
-                            content: content, 
+                            content: content,
                         },
                     });
                 }

--- a/packages/virtual-tour-plugin/src/model.ts
+++ b/packages/virtual-tour-plugin/src/model.ts
@@ -69,6 +69,11 @@ export type VirtualTourTransitionOptions = {
      */
     speed?: string | number;
     /**
+     * show the loader while loading the new panorama
+     * @default true
+     */
+    showLoader?: boolean;
+    /**
      * Enable fade-in between nodes
      * @default true
      */
@@ -216,10 +221,10 @@ export type VirtualTourPluginConfig = {
 
     /**
      * Configuration of the transition between nodes. Can be a callback.
-     * @default `{ speed: '20rpm', fadeIn: true, rotation: true }`
+     * @default `{ speed: '20rpm', fadeIn: true, rotation: true, showLoader: true }`
      */
     transitionOptions?:
-        | Pick<VirtualTourTransitionOptions, 'speed' | 'fadeIn' | 'rotation'>
+        | Pick<VirtualTourTransitionOptions, 'speed' | 'fadeIn' | 'rotation' | 'showLoader'>
         | ((
               toNode: VirtualTourNode,
               fromNode?: VirtualTourNode,


### PR DESCRIPTION
**Merge request checklist**

-   [x] All lints and tests pass. If needed, new unit tests were added.
-   [ ] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.


## Needed changes in [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/blob/main/docs/plugins/virtual-tour.md#transitionoptions):


#### `transitionOptions`

-   type: `object | function`
-   default: `{ speed: '20rpm', fadeIn: true, rotation: true, showLoader: true }`
-   updatable: no

Configuration of the transition between nodes. Can be a callback.

::: dialog "See details" "Virtual tour transitionOptions"

`transitionOptions` can be defined as a static object or a function called before switching to a new node.

The default behaviour is to rotate the view to face the direction of the link and perform a fade-in transition to the next node.

**If defined as an object, the type is:**

```ts
{
    /**
     * Speed or duration of the transition between nodes
     * @default '20rpm'
     */
    speed?: string | number;
    /**
     * show the loader while loading the new panorama
     * @default true
    */
    showLoader?: boolean;
    /**
     * Enable fade-in between nodes
     * @default true
     */
    fadeIn?: boolean;
    /**
     * Enable rotation in the direction of the next node
     * @default true
     */
    rotation?: boolean;
}
```

**If defined as a function, the signature is:**

```ts
(toNode: Node, fromNode?: Node, fromLink?: NodeLink) => ({
    speed?: string | number;
    /**
     * show the loader while loading the new panorama
     * @default true
    */
    showLoader?: boolean;
    fadeIn?: boolean;
    rotation?: boolean;
    /**
     * Define where to rotate the current panorama before switching to the next
     * if not defined it will use the link's position
     */
    rotateTo?: Position;
    /**
     * Define the new zoom level
     * if not defined it will keep the current zoom level
     */
    zoomTo?: number;
})
```

:::