### PR TITLE
chore: className for compass plugin

### DIFF
--- a/docs/plugins/compass.md
+++ b/docs/plugins/compass.md
@@ -201,6 +201,12 @@ Color of the navigation cone.
 
 Default color of hotspots.
 
+#### `className`
+
+-   type: `string`
+
+CSS class(es) added to the compass element.
+
 ## Methods
 
 #### `setHotspots(hotspots)`

--- a/docs/plugins/compass.md
+++ b/docs/plugins/compass.md
@@ -204,6 +204,7 @@ Default color of hotspots.
 #### `className`
 
 -   type: `string`
+-   updatable: yes
 
 CSS class(es) added to the compass element.
 

--- a/packages/compass-plugin/src/CompassPlugin.ts
+++ b/packages/compass-plugin/src/CompassPlugin.ts
@@ -15,7 +15,7 @@ const getConfig = utils.getConfigParser<CompassPluginConfig, ParsedCompassPlugin
         navigationColor: 'rgba(255, 0, 0, 0.2)',
         hotspots: [],
         hotspotColor: 'rgba(0, 0, 0, 0.5)',
-        className: ''
+        className: null
     },
     {
         position: (position, { defValue }) => {

--- a/packages/compass-plugin/src/CompassPlugin.ts
+++ b/packages/compass-plugin/src/CompassPlugin.ts
@@ -15,6 +15,7 @@ const getConfig = utils.getConfigParser<CompassPluginConfig, ParsedCompassPlugin
         navigationColor: 'rgba(255, 0, 0, 0.2)',
         hotspots: [],
         hotspotColor: 'rgba(0, 0, 0, 0.5)',
+        className: ''
     },
     {
         position: (position, { defValue }) => {

--- a/packages/compass-plugin/src/components/CompassComponent.ts
+++ b/packages/compass-plugin/src/components/CompassComponent.ts
@@ -91,6 +91,11 @@ export class CompassComponent extends AbstractComponent {
 
     applyConfig() {
         this.container.className = `psv-compass psv-compass--${this.config.position.join('-')}`;
+
+        if (this.config.className) {
+            utils.addClasses(this.container, this.config.className);
+        }
+
         this.background.innerHTML = this.config.backgroundSvg;
 
         this.container.style.width = this.config.size;

--- a/packages/compass-plugin/src/model.ts
+++ b/packages/compass-plugin/src/model.ts
@@ -53,6 +53,10 @@ export type CompassPluginConfig = {
      * @default 'rgba(0, 0, 0, 0.5)'
      */
     hotspotColor?: string;
+
+    /**
+     * CSS class(es) added to the compass element.
+     */
     className?: string;
 };
 

--- a/packages/compass-plugin/src/model.ts
+++ b/packages/compass-plugin/src/model.ts
@@ -53,6 +53,7 @@ export type CompassPluginConfig = {
      * @default 'rgba(0, 0, 0, 0.5)'
      */
     hotspotColor?: string;
+    className?: string;
 };
 
 export type ParsedCompassPluginConfig = Omit<CompassPluginConfig, 'position'> & {


### PR DESCRIPTION
**Merge request checklist**

-   [x] All lints and tests pass. If needed, new unit tests were added.
-   [ ] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.

ClassName for compass. for example `position: [string, string]` may not ehough for positioning