### PR TITLE
Tryed to remove black border in EquirectangularAdapter if blur enabled

### DIFF
--- a/packages/core/src/adapters/EquirectangularAdapter.ts
+++ b/packages/core/src/adapters/EquirectangularAdapter.ts
@@ -272,15 +272,18 @@ export class EquirectangularAdapter extends AbstractAdapter<string, Texture, Pan
 
             if (this.config.blur) {
                 ctx.filter = `blur(${buffer.width / 2048}px)`;
+                // add -0.1% of margin to avoid black borders
+                const m = buffer.width * 0.001;
+                ctx.drawImage(img, -m, -m, buffer.width + m * 2, buffer.height + m * 2);
+            } else {
+                ctx.drawImage(
+                    img,
+                    resizedPanoData.croppedX,
+                    resizedPanoData.croppedY,
+                    resizedPanoData.croppedWidth,
+                    resizedPanoData.croppedHeight
+                );
             }
-
-            ctx.drawImage(
-                img,
-                resizedPanoData.croppedX,
-                resizedPanoData.croppedY,
-                resizedPanoData.croppedWidth,
-                resizedPanoData.croppedHeight
-            );
 
             const t = createTexture(buffer);
 


### PR DESCRIPTION
This commit changes the image rendering logic in the EquirectangularAdapter class.
If the config.blur flag is set,  adds a margin to avoid black borders.
Otherwise, it draws the image as previous.
This change is not the best solution possible but for me it's more annoying if I see a black line than cropping a fiew pixels.

If you try, it's not really easy to notice this small crop.

I basically apply a margin of 0.1% calculated over the width of the panorama so as to hide the shaded border.

**Merge request checklist**

-   [X] All lints and tests pass. If needed, new unit tests were added.
-   [X] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.
