### PR TITLE
Add autoplay option for videoLayer markers

### DIFF
--- a/docs/plugins/markers.md
+++ b/docs/plugins/markers.md
@@ -592,6 +592,13 @@ The name that appears in the list of markers. If not provided, the tooltip conte
 
 Hide the marker in the markers list.
 
+#### `autoplay`
+
+-   type: `boolean`
+-   default: `true`
+
+Autoplay of `videoLayer` markers
+
 #### `data`
 
 -   type: `any`

--- a/packages/markers-plugin/src/markers/Marker3D.ts
+++ b/packages/markers-plugin/src/markers/Marker3D.ts
@@ -170,7 +170,7 @@ export class Marker3D extends Marker {
                         src: this.config.videoLayer,
                         withCredentials: this.viewer.config.withCredentials,
                         muted: true,
-                        autoplay: true,
+                        autoplay: this.config.autoplay ?? true,
                     });
 
                     const texture = new VideoTexture(video);
@@ -189,8 +189,6 @@ export class Marker3D extends Marker {
                             this.__setTextureWrap(material);
                         }
                     }, { once: true });
-
-                    video.play();
 
                     this.definition = this.config.videoLayer;
                 } else {

--- a/packages/markers-plugin/src/model.ts
+++ b/packages/markers-plugin/src/model.ts
@@ -184,6 +184,11 @@ export type MarkerConfig = {
      */
     hideList?: boolean;
     /**
+     * Autoplay of `videoLayer` markers
+     * @default true
+     */
+    autoplay?: boolean;
+    /**
      * Any custom data you want to attach to the marker
      */
     data?: any;


### PR DESCRIPTION
These changes make it possible to disable the automatic playback of videoLayers. If you do this via an event listener and pause(), often it still throws unnecessary AbortError errors due to the autoplay policies of modern browsers.

To be backwards compatible, it defaults to autoplay enabled.

**Merge request checklist**

-   [x] All lints and tests pass. If needed, new unit tests were added.
-   [x] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.

