### PR TITLE
Add missing export to OverlaysPlugin

### DIFF
--- a/packages/overlays-plugin/src/index.ts
+++ b/packages/overlays-plugin/src/index.ts
@@ -2,3 +2,4 @@ import * as events from './events';
 
 export { OverlaysPlugin } from './OverlaysPlugin';
 export { events };
+export * from './model';


### PR DESCRIPTION
Add the export of all types of the OverlaysPlugin (e. g. OverlaysPluginConfig). Those were not accessible before which is visible at the api-docs currently: https://photo-sphere-viewer.js.org/api/modules/overlaysplugin

**Merge request checklist**

-   [ ] All lints and tests pass. If needed, new unit tests were added.
-   [x] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.
