### PR TITLE
docs(virtual-tour-plugin): Correct arrowStyle docs

### DIFF
--- a/docs/plugins/virtual-tour.md
+++ b/docs/plugins/virtual-tour.md
@@ -426,7 +426,7 @@ Each node can still have a `map` property to override `color`, `image` and `size
 
 Callback used to replace/modify the tooltip for a link. The first parameter is the default tooltip content which contains the node `name` + `thumbnail` + `caption`.
 
-#### `arrowStyle` (3d mode only)
+#### `arrowStyle`
 
 -   type: `object`
 -   updatable: no


### PR DESCRIPTION
**Merge request checklist**

-   [ ] All lints and tests pass. If needed, new unit tests were added.
-   [ ] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.

The docs previously stated that the virtual-tour plugin `arrowStyle` config is only applicable in 3D mode, but that's incorrect. The `arrowStyle` config is applicable in both 2D and 3D mode.

This was clarified in https://github.com/mistic100/Photo-Sphere-Viewer/issues/1420#issuecomment-2327473908