### PR TITLE
docs: Fix typo in docs and code comments

### DIFF
--- a/docs/demos/markers/layers.md
+++ b/docs/demos/markers/layers.md
@@ -64,7 +64,7 @@ markers.addEventListener('select-marker', ({ marker }) => {
     }
 });
 
-// bellow is custom animation to make Rick's position change
+// below is custom animation to make Rick's position change
 
 const positions = [
     [

--- a/docs/plugins/gallery.md
+++ b/docs/plugins/gallery.md
@@ -63,7 +63,7 @@ packages:
 -   type: `GalleryItem[]`
 -   updatable: no, use `setItems()` method
 
-The list of items, see bellow.
+The list of items, see below.
 
 #### `visibleOnLoad`
 
@@ -153,7 +153,7 @@ If you use a [custom navbar](../guide/navbar.md) you will need to manually add t
 
 | variable | default | description |
 | -------- | ------- | ----------- |
-| $psv-gallery-breakpoint | 500px | Screen size bellow which the gallery is displayed full-height |
+| $psv-gallery-breakpoint | 500px | Screen size below which the gallery is displayed full-height |
 | $psv-gallery-padding | 15px | Padding of the container |
 | $psv-gallery-border | 1px solid $psv-caption-text-color | Border between the gallery and the navbar |
 | $psv-gallery-background | $psv-navbar-background | Background of the gallery |

--- a/docs/plugins/map.md
+++ b/docs/plugins/map.md
@@ -154,7 +154,7 @@ Size of the cone of the compass.
 -   default: `null`
 -   updatable: yes
 
-Small dots visible on the map. See bellow. You can also use `setHotspots()` method.
+Small dots visible on the map. See below. You can also use `setHotspots()` method.
 
 #### `spotStyle`
 

--- a/docs/plugins/overlays.md
+++ b/docs/plugins/overlays.md
@@ -82,7 +82,7 @@ Overlays seem very similar to image/video markers but serve different purposes:
 -   type: `OverlayConfig[]`
 -   updatable: no
 
-The list of overlays, see bellow. Can be updated with various [methods](#methods).
+The list of overlays, see below. Can be updated with various [methods](#methods).
 
 #### `autoclear`
 

--- a/docs/plugins/plan.md
+++ b/docs/plugins/plan.md
@@ -151,7 +151,7 @@ Size of the central pin.
 -   default: `null`
 -   updatable: yes
 
-Markers visible on the map. See bellow. You can also use `setHotspots()` method.
+Markers visible on the map. See below. You can also use `setHotspots()` method.
 
 #### `spotStyle`
 

--- a/docs/plugins/virtual-tour.md
+++ b/docs/plugins/virtual-tour.md
@@ -134,7 +134,7 @@ Refer to the main [config page](../guide/config.md).
 
 -   type: `array`
 
-Definition of the links of this node. [See bellow](#links).
+Definition of the links of this node. [See below](#links).
 
 #### `gps` (required in GPS mode)
 

--- a/packages/core/src/data/constants.ts
+++ b/packages/core/src/data/constants.ts
@@ -19,7 +19,7 @@ export const DEFAULT_TRANSITION = 1500;
 export const ANIMATION_MIN_DURATION = 500;
 
 /**
- * Number of pixels bellow which a mouse move will be considered as a click
+ * Number of pixels below which a mouse move will be considered as a click
  */
 export const MOVE_THRESHOLD = 4;
 

--- a/packages/equirectangular-tiles-adapter/src/EquirectangularTilesAdapter.ts
+++ b/packages/equirectangular-tiles-adapter/src/EquirectangularTilesAdapter.ts
@@ -12,7 +12,7 @@ import { EquirectangularTileConfig, checkPanoramaConfig, getTileConfig, getTileC
 
 /* the faces of the top and bottom rows are made of a single triangle (3 vertices)
  * all other faces are made of two triangles (6 vertices)
- * bellow is the indexing of each face vertices
+ * below is the indexing of each face vertices
  *
  * first row faces:
  *     ⋀


### PR DESCRIPTION
**Merge request checklist**

-   [ ] All lints and tests pass. If needed, new unit tests were added.
-   [ ] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.

A tiny typo fix.

I see many places in the docs where *below* is spelled as *bellow*, this PR attempts to fix that.