### PR TITLE
docs(marker-plugin): Fix broken link in docs

### DIFF
--- a/docs/plugins/markers.md
+++ b/docs/plugins/markers.md
@@ -205,7 +205,7 @@ Existing DOM element.
 }
 ```
 
-[Check the demo](../demos//markers//youtube-element.md)
+[Check the demo](../demos/markers/youtube-element.md)
 
 #### `polygon`
 


### PR DESCRIPTION
**Merge request checklist**

-   [ ] All lints and tests pass. If needed, new unit tests were added.
-   [ ] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.

The link to the demo in the `elementLayer` section of the marker docs is invalid(extra `/` characters). This PR fixes that.