### PR TITLE
Tile loading concurrency config

### DIFF
--- a/packages/shared/Queue.ts
+++ b/packages/shared/Queue.ts
@@ -50,7 +50,7 @@ export class Queue {
     private runningTasks: Record<string, boolean> = {};
     private tasks: Record<string, Task> = {};
 
-    constructor(private readonly concurency = 4) {}
+    constructor(private readonly concurency = 8) {}
 
     enqueue(task: Task) {
         this.tasks[task.id] = task;


### PR DESCRIPTION
**Merge request checklist**

-   [x] All lints and tests pass. If needed, new tests were added.
-   [x] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.

Possibility to control the loading queue concurrency for tiles adapter