### PR TITLE
Add shader support for sphereCorrection and pose in equirectangular panoramas

### DIFF
--- a/packages/core/src/adapters/shaders/equirectangular.fragment.glsl
+++ b/packages/core/src/adapters/shaders/equirectangular.fragment.glsl
@@ -1,4 +1,5 @@
-varying vec3 vWorldPos;
+varying vec3 vLocalPos;
+varying vec3 vLocalCam;
 uniform sampler2D map;
 uniform float opacity;
 uniform vec2 uvOffset;
@@ -9,31 +10,45 @@ const float PI = 3.1415926535897932384626433832795;
 
 // Analytic edge antialiasing across one screen-space pixel at the
 // cropped-region boundary on a single axis (replaces the MSAA the standard
-// adapter gets from rasterizing arc-restricted geometry).
-float edgeAlpha(float coord) {
+// adapter gets by rendering triangles).
+float edgeAlpha(float coord, float width) {
     float dist = min(coord, 1.0 - coord);
-    return clamp(dist / fwidth(coord) + 0.5, 0.0, 1.0);
+    return clamp(dist / width + 0.5, 0.0, 1.0);
+}
+
+// Screen-space derivative (fwidth) of a coordinate that wraps in [0, 1], such
+// as longitude at the antimeridian. A naive fwidth() spikes to ~1.0 across the
+// seam. Removing the integer jump keeps the result sub-pixel. Assumes the
+// per-pixel change stays well under 0.5, so only the wrap rounds to a non-zero
+// integer (safe unless a pixel spans ~180deg of longitude).
+float fwidthWrapped(float coord) {
+    float dx = dFdx(coord); dx -= floor(dx + 0.5);
+    float dy = dFdy(coord); dy -= floor(dy + 0.5);
+    return abs(dx) + abs(dy);
 }
 
 void main() {
     // Ray-cast the true sphere from the camera through the (interpolated, on
-    // the polygon chord) world position, and use the exit-point direction for
+    // the polygon chord) position, and use the exit-point direction for
     // sampling. This makes the result independent of mesh tessellation even
     // when the camera is offset from the sphere center (e.g. fisheye config).
-    vec3 rayDir = vWorldPos - cameraPosition;
+    // Inputs are already in the panorama's local frame (see vertex shader), so
+    // the exit direction is too and needs no further rotation.
+    vec3 rayDir = vLocalPos - vLocalCam;
     float a = dot(rayDir, rayDir);
-    float b = dot(cameraPosition, rayDir);
-    float c = dot(cameraPosition, cameraPosition) - radius * radius;
+    float b = dot(vLocalCam, rayDir);
+    float c = dot(vLocalCam, vLocalCam) - radius * radius;
     float t = (-b + sqrt(max(b * b - a * c, 0.0))) / a;
-    vec3 dir = (cameraPosition + t * rayDir) / radius;
+    vec3 dir = (vLocalCam + t * rayDir) / radius;
 
     float u = atan(-dir.x, dir.z) / (2.0 * PI) + 0.5;
     float v = asin(clamp(dir.y, -1.0, 1.0)) / PI + 0.5;
     vec2 uv = (vec2(u, v) - uvOffset) / uvScale;
 
     float alpha = 1.0;
-    if (uvScale.x < 1.0) alpha = min(alpha, edgeAlpha(uv.x));
-    if (uvScale.y < 1.0) alpha = min(alpha, edgeAlpha(uv.y));
+    // `u` wraps at the antimeridian, so derive its width safely.
+    if (uvScale.x < 1.0) alpha = min(alpha, edgeAlpha(uv.x, fwidthWrapped(u) / uvScale.x));
+    if (uvScale.y < 1.0) alpha = min(alpha, edgeAlpha(uv.y, fwidth(uv.y)));
     if (alpha <= 0.0) discard;
 
     gl_FragColor = texture2D(map, uv);

--- a/packages/core/src/adapters/shaders/equirectangular.vertex.glsl
+++ b/packages/core/src/adapters/shaders/equirectangular.vertex.glsl
@@ -1,6 +1,15 @@
-varying vec3 vWorldPos;
+// Ray-cast inputs in the panorama's local frame, so sphereCorrection and pose
+// (both folded into modelMatrix) apply to the sampled direction without
+// per-fragment work.
+varying vec3 vLocalPos;
+varying vec3 vLocalCam;
 
 void main() {
-    vWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;
+    vLocalPos = position;
+
+    // mat3(modelMatrix) is a pure rotation, so its inverse is its transpose:
+    // `cameraPosition * M == transpose(M) * cameraPosition`.
+    vLocalCam = cameraPosition * mat3(modelMatrix);
+
     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
 }


### PR DESCRIPTION
Adds support for sphereCorrection and pose in equirectangular panoramas when the shader option is set. Also fixes an anti-aliasing artifact in cropped panoramas at the antimeridian seam.

**Merge request checklist**

-   [x] All lints and tests pass. If needed, new tests were added.
-   [x] If needed, the [documentation](https://github.com/mistic100/Photo-Sphere-Viewer/tree/main/docs) has been updated.
